### PR TITLE
fix(ipns): fail fast and fix rpc encoding

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -121,7 +121,7 @@ func (api *bifrostGateway) GetIPNSRecord(ctx context.Context, c cid.Cid) ([]byte
 		return nil, errors.New("provided cid is not an encoded libp2p key")
 	}
 
-	// The value store expects the key itself to be encoded as a multihash.
+	// The value store expects the key itself to be multihash.
 	id, err := peer.FromCid(c)
 	if err != nil {
 		return nil, err

--- a/gateway.go
+++ b/gateway.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	gopath "path"
 
@@ -28,7 +29,9 @@ import (
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/node/basicnode"
 	"github.com/ipld/go-ipld-prime/schema"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/routing"
+	mc "github.com/multiformats/go-multicodec"
 )
 
 type bifrostGateway struct {
@@ -112,7 +115,19 @@ func (api *bifrostGateway) GetBlock(ctx context.Context, c cid.Cid) (blocks.Bloc
 }
 
 func (api *bifrostGateway) GetIPNSRecord(ctx context.Context, c cid.Cid) ([]byte, error) {
-	return api.routing.GetValue(ctx, "/ipns/"+c.String())
+	// Fails fast if the CID is not an encoded Libp2p Key, avoids wasteful
+	// round trips to the remote routing provider.
+	if mc.Code(c.Type()) != mc.Libp2pKey {
+		return nil, errors.New("provided cid is not an encoded libp2p key")
+	}
+
+	// The value store expects the key itself to be encoded as a multihash.
+	id, err := peer.FromCid(c)
+	if err != nil {
+		return nil, err
+	}
+
+	return api.routing.GetValue(ctx, "/ipns/"+string(id))
 }
 
 func (api *bifrostGateway) GetDNSLinkRecord(ctx context.Context, hostname string) (ifacepath.Path, error) {

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/ipld/go-codec-dagpb v1.5.0
 	github.com/ipld/go-ipld-prime v0.19.0
 	github.com/libp2p/go-libp2p v0.23.4
+	github.com/multiformats/go-multicodec v0.7.0
 	github.com/prometheus/client_golang v1.14.0
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
@@ -85,7 +86,6 @@ require (
 	github.com/multiformats/go-multiaddr v0.8.0 // indirect
 	github.com/multiformats/go-multiaddr-dns v0.3.1 // indirect
 	github.com/multiformats/go-multibase v0.1.1 // indirect
-	github.com/multiformats/go-multicodec v0.7.0 // indirect
 	github.com/multiformats/go-multihash v0.2.1 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/opencontainers/runtime-spec v1.0.3-0.20211123151946-c2389c3cb60a // indirect

--- a/routing.go
+++ b/routing.go
@@ -98,7 +98,7 @@ func (ps *proxyRouting) fetch(ctx context.Context, key string) ([]byte, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status from remote gateway: %s", resp.Status)
+		return nil, fmt.Errorf("routing/get RPC returned unexpected status: %s", resp.Status)
 	}
 
 	rb, err := io.ReadAll(resp.Body)
@@ -113,7 +113,7 @@ func (ps *proxyRouting) fetch(ctx context.Context, key string) ([]byte, error) {
 		var evt routing.QueryEvent
 		err = json.Unmarshal(part, &evt)
 		if err != nil {
-			return nil, fmt.Errorf("routing/get value cannot be parsed: %w", err)
+			return nil, fmt.Errorf("routing/get RPC response cannot be parsed: %w", err)
 		}
 
 		if evt.Type == routing.Value {
@@ -123,7 +123,7 @@ func (ps *proxyRouting) fetch(ctx context.Context, key string) ([]byte, error) {
 	}
 
 	if b64 == "" {
-		return nil, errors.New("routing/get value has no key")
+		return nil, errors.New("routing/get RPC returned no value")
 	}
 
 	rb, err = base64.StdEncoding.DecodeString(b64)


### PR DESCRIPTION
See https://github.com/ipfs/bifrost-gateway/pull/10#discussion_r1099587452.

Also fixes the `routing.GetValue` call. I confused it with the `CoreAPI.Routing().Get()` which expects the path as a string. `routing.ValueStore` expects the multihash encoded version of the path.

Also added this improvement and fix to the Gateway example: https://github.com/ipfs/go-libipfs/pull/158

Hopefully all this errors will be caught once we run this against the gateway tests.