### PR TITLE
feat: expose ipfs_http_response_size_bytes_sum and caboose metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/filecoin-saturn/caboose"
 	"github.com/ipfs/go-blockservice"
 	offline "github.com/ipfs/go-ipfs-exchange-offline"
 	"github.com/ipfs/go-libipfs/gateway"
@@ -171,7 +172,13 @@ func makeGatewayHandler(saturnOrchestrator, saturnLogger string, kuboRPC []strin
 
 func makeMetricsHandler(port int) (*http.Server, error) {
 	mux := http.NewServeMux()
-	mux.Handle("/debug/metrics/prometheus", promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{}))
+
+	gatherers := prometheus.Gatherers{
+		prometheus.DefaultGatherer,
+		caboose.CabooseMetrics,
+	}
+	options := promhttp.HandlerOpts{}
+	mux.Handle("/debug/metrics/prometheus", promhttp.HandlerFor(gatherers, options))
 
 	return &http.Server{
 		Handler: mux,

--- a/main.go
+++ b/main.go
@@ -144,8 +144,27 @@ func makeGatewayHandler(saturnOrchestrator, saturnLogger string, kuboRPC []strin
 		},
 	}
 
+	// Creates metrics handler for total response size. Matches the same metrics
+	// from Kubo:
+	// https://github.com/ipfs/kubo/blob/e550d9e4761ea394357c413c02ade142c0dea88c/core/corehttp/metrics.go#L79-L152
+	sum := prometheus.NewSummaryVec(prometheus.SummaryOpts{
+		Namespace:  "ipfs",
+		Subsystem:  "http",
+		Name:       "response_size_bytes",
+		Help:       "The HTTP response sizes in bytes.",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+	}, nil)
+	err = prometheus.Register(sum)
+	if err != nil {
+		return nil, err
+	}
+
+	// Construct the HTTP handler for the gateway.
+	handler := http.Handler(gateway.WithHostname(mux, gwAPI, publicGateways, noDNSLink))
+	handler = promhttp.InstrumentHandlerResponseSize(sum, handler)
+
 	return &http.Server{
-		Handler: gateway.WithHostname(mux, gwAPI, publicGateways, noDNSLink),
+		Handler: handler,
 		Addr:    ":" + strconv.Itoa(port),
 	}, nil
 }


### PR DESCRIPTION
Exposes `ipfs_http_response_size_bytes_sum` according to https://github.com/ipfs/bifrost-gateway/issues/8#issuecomment-1421974710, also caboose metrics.