### PR TITLE
feat: smart /api/v0 handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -211,7 +211,7 @@ func newAPIHandler(endpoints []string) http.Handler {
 	// Remaining requests to the API receive a 501, as well as an explanation.
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotImplemented)
-		w.Write([]byte("/api/v0 RPC will be removed from gateways as it is not part of the gateway specification, but a legacy feature from Kubo. If you need this API, please self-host a Kubo instance yourself: docs.ipfs.tech/install/command-line"))
+		w.Write([]byte("The /api/v0 Kubo RPC is now discontinued on this server as it is not part of the gateway specification. If you need this API, please self-host a Kubo instance yourself: https://docs.ipfs.tech/install/command-line/"))
 	})
 
 	return mux

--- a/main.go
+++ b/main.go
@@ -181,6 +181,12 @@ func newAPIHandler(endpoints []string) http.Handler {
 		http.Redirect(w, r, url, http.StatusFound)
 	})
 
+	mux.HandleFunc("/api/v0/dag/export", func(w http.ResponseWriter, r *http.Request) {
+		cid := r.URL.Query().Get("arg")
+		url := fmt.Sprintf("/ipfs/%s?format=car", cid)
+		http.Redirect(w, r, url, http.StatusFound)
+	})
+
 	mux.HandleFunc("/api/v0/block/get", func(w http.ResponseWriter, r *http.Request) {
 		cid := r.URL.Query().Get("arg")
 		url := fmt.Sprintf("/ipfs/%s?format=raw", cid)


### PR DESCRIPTION
Closes #13. I also implemented @aschmahmann comment regarding `dag/export`. I checked the API and there are no additional options that could lead to incompatibilities. The only option is `progress` which is useless for remote calls.