### PR TITLE
fix: ensure correct Method and Location on RPC API redirect

### DIFF
--- a/handler_test.go
+++ b/handler_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type rpcRedirectTest struct {
+	url      string
+	location string
+	status   int
+}
+
+func TestRPCRedirectsToGateway(t *testing.T) {
+	rpcHandler := newKuboRPCHandler([]string{"http://example.com"})
+
+	tests := []rpcRedirectTest{
+		{"/api/v0/cat?arg=bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e", "/ipfs/bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e", http.StatusSeeOther},
+		{"/api/v0/cat?arg=/ipfs/bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e", "/ipfs/bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e", http.StatusSeeOther},
+		{"/api/v0/cat?arg=/ipns/k51qzi5uqu5dgutdk6i1ynyzgkqngpha5xpgia3a5qqp4jsh0u4csozksxel2r", "/ipns/k51qzi5uqu5dgutdk6i1ynyzgkqngpha5xpgia3a5qqp4jsh0u4csozksxel2r", http.StatusSeeOther},
+
+		{"/api/v0/dag/get?arg=bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e", "/ipfs/bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e?format=dag-json", http.StatusSeeOther},
+		{"/api/v0/dag/get?arg=/ipfs/bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e", "/ipfs/bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e?format=dag-json", http.StatusSeeOther},
+		{"/api/v0/dag/get?arg=/ipns/k51qzi5uqu5dgutdk6i1ynyzgkqngpha5xpgia3a5qqp4jsh0u4csozksxel2r", "/ipns/k51qzi5uqu5dgutdk6i1ynyzgkqngpha5xpgia3a5qqp4jsh0u4csozksxel2r?format=dag-json", http.StatusSeeOther},
+		{"/api/v0/dag/get?arg=bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e&output-codec=dag-cbor", "/ipfs/bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e?format=dag-cbor", http.StatusSeeOther},
+
+		{"/api/v0/dag/export?arg=bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e", "/ipfs/bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e?format=car", http.StatusSeeOther},
+		{"/api/v0/dag/export?arg=/ipfs/bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e", "/ipfs/bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e?format=car", http.StatusSeeOther},
+		{"/api/v0/dag/export?arg=/ipns/k51qzi5uqu5dgutdk6i1ynyzgkqngpha5xpgia3a5qqp4jsh0u4csozksxel2r", "/ipns/k51qzi5uqu5dgutdk6i1ynyzgkqngpha5xpgia3a5qqp4jsh0u4csozksxel2r?format=car", http.StatusSeeOther},
+
+		{"/api/v0/block/get?arg=bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e", "/ipfs/bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e?format=raw", http.StatusSeeOther},
+		{"/api/v0/block/get?arg=/ipfs/bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e", "/ipfs/bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e?format=raw", http.StatusSeeOther},
+		{"/api/v0/block/get?arg=/ipns/k51qzi5uqu5dgutdk6i1ynyzgkqngpha5xpgia3a5qqp4jsh0u4csozksxel2r", "/ipns/k51qzi5uqu5dgutdk6i1ynyzgkqngpha5xpgia3a5qqp4jsh0u4csozksxel2r?format=raw", http.StatusSeeOther},
+	}
+
+	for _, test := range tests {
+		for _, method := range []string{http.MethodGet, http.MethodPost} {
+			req, err := http.NewRequest(method, "http://127.0.0.1"+test.url, nil)
+			assert.Nil(t, err)
+			resp := httptest.NewRecorder()
+			rpcHandler.ServeHTTP(resp, req)
+
+			assert.Equal(t, test.status, resp.Code)
+			assert.Equal(t, test.location, resp.Header().Get("Location"))
+		}
+	}
+}
+
+func TestRPCRedirectsToKubo(t *testing.T) {
+	rpcHandler := newKuboRPCHandler([]string{"http://example.com"})
+
+	tests := []rpcRedirectTest{
+		{"/api/v0/name/resolve?arg=some-arg", "http://example.com/api/v0/name/resolve?arg=some-arg", http.StatusTemporaryRedirect},
+		{"/api/v0/resolve?arg=some-arg", "http://example.com/api/v0/resolve?arg=some-arg", http.StatusTemporaryRedirect},
+		{"/api/v0/dag/resolve?arg=some-arg", "http://example.com/api/v0/dag/resolve?arg=some-arg", http.StatusTemporaryRedirect},
+		{"/api/v0/dns?arg=some-arg", "http://example.com/api/v0/dns?arg=some-arg", http.StatusTemporaryRedirect},
+	}
+
+	for _, test := range tests {
+		for _, method := range []string{http.MethodGet, http.MethodPost} {
+			req, err := http.NewRequest(method, "http://127.0.0.1"+test.url, nil)
+			assert.Nil(t, err)
+			resp := httptest.NewRecorder()
+			rpcHandler.ServeHTTP(resp, req)
+
+			assert.Equal(t, test.status, resp.Code)
+			assert.Equal(t, test.location, resp.Header().Get("Location"))
+		}
+	}
+}
+
+func TestRPCNotImplemented(t *testing.T) {
+	rpcHandler := newKuboRPCHandler([]string{"http://example.com"})
+
+	for _, method := range []string{http.MethodGet, http.MethodPost} {
+		req, err := http.NewRequest(method, "http://127.0.0.1/api/v0/ping", nil)
+		assert.Nil(t, err)
+		resp := httptest.NewRecorder()
+		rpcHandler.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusNotImplemented, resp.Code)
+	}
+}


### PR DESCRIPTION
This PR makes two changes:

- RPC API that redirects to Gateway uses **303 See Other**, as it [ensures](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303) the new request uses GET - and the gateway is GET only. 302 does [not ensure](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302) as it is underspecified.
- RPC API that redirects to a different Kubo node uses **307 Temporary Redirect**, to ensure the new request [preserves](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307) the method and body of the original request.

Additionally, it fixes the redirects to support IPFS paths and not only CIDs, as that's how the API behaves. It also adds tests to ensure the redirects have the correct Location and status code.