### PR TITLE
feat: introduce block fetching timeout (30s)

### DIFF
--- a/blockstore.go
+++ b/blockstore.go
@@ -27,6 +27,9 @@ type exchangeBsWrapper struct {
 }
 
 func (e *exchangeBsWrapper) GetBlock(ctx context.Context, c cid.Cid) (blocks.Block, error) {
+	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
 	return e.bstore.Get(ctx, c)
 }
 


### PR DESCRIPTION
Adds a timeout for fetching a block of 30s, such that we do not let users waiting indefinitely (#21). Perhaps we should tackle it and make it a different number. 