### PR TITLE
chore: adjust GetBlockTimeout to 60s

### DIFF
--- a/blockstore.go
+++ b/blockstore.go
@@ -14,7 +14,7 @@ import (
 	blocks "github.com/ipfs/go-libipfs/blocks"
 )
 
-const GetBlockTimeout = time.Second * 30
+const GetBlockTimeout = time.Second * 60
 
 func newExchange(orchestrator, loggingEndpoint string) (exchange.Interface, error) {
 	b, err := newBlockStore(orchestrator, loggingEndpoint)


### PR DESCRIPTION
per-block timeout was introduced in https://github.com/ipfs/bifrost-gateway/pull/29 

we have `proxy_read_timeout 60;` on LB nodes, so the old setup on `ipfs.io` will cut-off after 60s of not receiving any new bytes from Kubo.

This PR should align  bifrost-gateway behavior closer to what the old setup did, which will help us compare latency and errors.

We most likely will adjust it in near future, but for M0.2 we want to compare apples to kinda-the-same-size-oranges.