### PR TITLE
feat: improved http limits and dns cache

### DIFF
--- a/blockstore.go
+++ b/blockstore.go
@@ -2,12 +2,8 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
-	"net/http"
-	"net/url"
 	"time"
 
-	"github.com/filecoin-saturn/caboose"
 	"github.com/ipfs/go-cid"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	exchange "github.com/ipfs/go-ipfs-exchange-interface"
@@ -65,54 +61,3 @@ func (e *exchangeBsWrapper) Close() error {
 }
 
 var _ exchange.Interface = (*exchangeBsWrapper)(nil)
-
-func newCabooseBlockStore(orchestrator, loggingEndpoint string) (blockstore.Blockstore, error) {
-	var (
-		orchURL *url.URL
-		loggURL *url.URL
-		err     error
-	)
-
-	if orchestrator != "" {
-		orchURL, err = url.Parse(orchestrator)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if loggingEndpoint != "" {
-		loggURL, err = url.Parse(loggingEndpoint)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	saturnClient := &http.Client{
-		Timeout: caboose.DefaultSaturnRequestTimeout,
-		Transport: &withUserAgent{
-			RoundTripper: &http.Transport{
-				TLSClientConfig: &tls.Config{
-					ServerName: "strn.pl",
-				},
-			},
-		},
-	}
-
-	saturnServiceClient := &http.Client{
-		Timeout:   caboose.DefaultSaturnRequestTimeout,
-		Transport: &withUserAgent{RoundTripper: http.DefaultTransport},
-	}
-
-	return caboose.NewCaboose(&caboose.Config{
-		OrchestratorEndpoint: orchURL,
-		OrchestratorClient:   saturnServiceClient,
-
-		LoggingEndpoint: *loggURL,
-		LoggingClient:   saturnServiceClient,
-		LoggingInterval: 5 * time.Second,
-
-		DoValidation: true,
-		PoolRefresh:  5 * time.Minute,
-		SaturnClient: saturnClient,
-	})
-}

--- a/blockstore_caboose.go
+++ b/blockstore_caboose.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/filecoin-saturn/caboose"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
+)
+
+func newCabooseBlockStore(orchestrator, loggingEndpoint string) (blockstore.Blockstore, error) {
+	var (
+		orchURL *url.URL
+		loggURL *url.URL
+		err     error
+	)
+
+	if orchestrator != "" {
+		orchURL, err = url.Parse(orchestrator)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if loggingEndpoint != "" {
+		loggURL, err = url.Parse(loggingEndpoint)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	saturnServiceClient := &http.Client{
+		Timeout: caboose.DefaultSaturnRequestTimeout,
+		Transport: &withUserAgent{
+			RoundTripper: &http.Transport{
+				DialContext: dialWithCachedDNS,
+			},
+		},
+	}
+
+	saturnRetrievalClient := &http.Client{
+		Timeout: caboose.DefaultSaturnRequestTimeout,
+		Transport: &withUserAgent{
+			RoundTripper: &http.Transport{
+				// Increasing concurrency defaults from http.DefaultTransport
+				MaxIdleConns:        1000,
+				MaxConnsPerHost:     100,
+				MaxIdleConnsPerHost: 100,
+				IdleConnTimeout:     90 * time.Second,
+
+				DialContext: dialWithCachedDNS,
+
+				// Saturn Weltschmerz
+				TLSClientConfig: &tls.Config{
+					// Saturn use TLS in controversial ways, which sooner or
+					// later will force them to switch away to different domain
+					// name and certs, in which case they will break us. Since
+					// we are fetching raw blocks and dont really care about
+					// TLS cert being legitimate, let's disable verification
+					// to save CPU and to avoid catastrophic failure when
+					// Saturn L1s suddenly switch to certs with different DNS name.
+					InsecureSkipVerify: true,
+					// ServerName:         "strn.pl",
+				},
+			},
+		},
+	}
+
+	return caboose.NewCaboose(&caboose.Config{
+		OrchestratorEndpoint: orchURL,
+		OrchestratorClient:   saturnServiceClient,
+
+		LoggingEndpoint: *loggURL,
+		LoggingClient:   saturnServiceClient,
+		LoggingInterval: 5 * time.Second,
+
+		DoValidation: true,
+		PoolRefresh:  5 * time.Minute,
+		SaturnClient: saturnRetrievalClient,
+	})
+}

--- a/dns_cache.go
+++ b/dns_cache.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/rs/dnscache"
+)
+
+// Local DNS cache because in this world things are ephemeral
+var dnsCache = &dnscache.Resolver{}
+
+// How often should we check for successful updates to cached entries
+const dnsCacheRefreshInterval = 5 * time.Minute
+
+func init() {
+	// Configure DNS cache to not remove stale records to protect gateway from
+	// catastrophic failures like https://github.com/ipfs/bifrost-gateway/issues/34
+	options := dnscache.ResolverRefreshOptions{}
+	options.ClearUnused = false
+	options.PersistOnFailure = false
+
+	// Every dnsCacheRefreshInterval we check for updates, but if there is
+	// none, or if domain disappears, we keep the last cached version
+	go func() {
+		t := time.NewTicker(dnsCacheRefreshInterval)
+		defer t.Stop()
+		for range t.C {
+			dnsCache.RefreshWithOptions(options)
+		}
+	}()
+}
+
+// dialWithCachedDNS implements DialContext that uses dnsCache
+func dialWithCachedDNS(ctx context.Context, network string, addr string) (conn net.Conn, err error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+	ips, err := dnsCache.LookupHost(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	// Try all IPs returned by DNS
+	for _, ip := range ips {
+		var dialer net.Dialer
+		conn, err = dialer.DialContext(ctx, network, net.JoinHostPort(ip, port))
+		if err == nil {
+			break
+		}
+	}
+	return
+}

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/libp2p/go-libp2p v0.25.1
 	github.com/multiformats/go-multicodec v0.7.0
 	github.com/prometheus/client_golang v1.14.0
+	github.com/rs/dnscache v0.0.0-20211102005908-e0241e321417
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
 	go.uber.org/atomic v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -932,6 +932,8 @@ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6So
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/rs/dnscache v0.0.0-20211102005908-e0241e321417 h1:Lt9DzQALzHoDwMBGJ6v8ObDPR0dzr2a6sXTB1Fq7IHs=
+github.com/rs/dnscache v0.0.0-20211102005908-e0241e321417/go.mod h1:qe5TWALJ8/a1Lqznoc5BDHpYX/8HU60Hm2AwRmqzxqA=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
This PR

- improves HTTP limits to allow more concurrency per L1 peer and in general
  - tested with `ab` and these new settings also pass the stress test from #41 
- removes TLS cert validation when we retrieve blocks from `strn.pl` because it has no value:
   -  `bifrost-gw` will fetch raw blocks and discard if received data does not match expected CID
   -  caboose should don't care if TLS cert is valid, nor if the name from cert matches DNS name, because we get raw IPs from orchestrator anyway, and faked it in TLS client :see_no_evil: 
   -  we don't want to break gateway if Saturn ever changes the name in their certs and our client starts erroring on TLS handshake
   - tldr: only value of TLS in `strn.pl` is that we can use HTTP/2, nothing more
- adds DNS cache that will not remove stale records if DNS zone suddenly disappears 
  - protects us from catastrophic failures like #34


Closes #34