### PR TITLE
feat: support STRN_LOGGER_SECRET

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,6 @@ MAINTAINER IPFS Stewards <w3dt-stewards-ip@protocol.ai>
 ENV GOPATH                 /go
 ENV SRC_PATH               /go/src/github.com/ipfs/bifrost-gateway
 ENV BIFROST_GATEWAY_PATH   /data/bifrost-gateway
-ENV STRN_ORCHESTRATOR_URL  https://orchestrator.strn.pl/nodes/nearby?count=1000&core=true
 ENV KUBO_RPC_URL           https://node0.delegate.ipfs.io,https://node1.delegate.ipfs.io,https://node2.delegate.ipfs.io,https://node3.delegate.ipfs.io
 
 COPY --from=builder $GOPATH/bin/bifrost-gateway /usr/local/bin/bifrost-gateway

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,6 @@ MAINTAINER IPFS Stewards <w3dt-stewards-ip@protocol.ai>
 ENV GOPATH                 /go
 ENV SRC_PATH               /go/src/github.com/ipfs/bifrost-gateway
 ENV BIFROST_GATEWAY_PATH   /data/bifrost-gateway
-ENV STRN_LOGGER_URL        https://twb3qukm2i654i3tnvx36char40aymqq.lambda-url.us-west-2.on.aws
 ENV STRN_ORCHESTRATOR_URL  https://orchestrator.strn.pl/nodes/nearby?count=1000&core=true
 ENV KUBO_RPC_URL           https://node0.delegate.ipfs.io,https://node1.delegate.ipfs.io,https://node2.delegate.ipfs.io,https://node3.delegate.ipfs.io
 

--- a/blockstore_proxy.go
+++ b/blockstore_proxy.go
@@ -22,6 +22,8 @@ import (
 // https://github.com/ipfs/specs/blob/main/http-gateways/TRUSTLESS_GATEWAY.md
 
 const (
+	EnvProxyGateway = "PROXY_GATEWAY_URL"
+
 	DefaultProxyGateway = "http://127.0.0.1:8080"
 	DefaultKuboPRC      = "http://127.0.0.1:5001"
 )
@@ -45,7 +47,7 @@ func newProxyBlockStore(gatewayURL []string, cdns *cachedDNS) blockstore.Blockst
 		gatewayURL: gatewayURL,
 		httpClient: &http.Client{
 			Timeout: GetBlockTimeout,
-			Transport: &withUserAgent{
+			Transport: &customTransport{
 				// Roundtripper with increased defaults than http.Transport such that retrieving
 				// multiple blocks from a single gateway concurrently is fast.
 				RoundTripper: &http.Transport{

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -51,7 +51,8 @@ Saturn Logger used for fraud detection.
 
 ### `STRN_LOGGER_SECRET`
 
-TODO [bifrost-gateway/issues/43](https://github.com/ipfs/bifrost-gateway/issues/43): Saturn Logger JWT used for fraud detection.
+JWT token provided by Saturn CDN. Staging (testnet) and production (mainnet)
+should use different tokens.
 
 ## Logging
 

--- a/handlers.go
+++ b/handlers.go
@@ -40,7 +40,7 @@ func withRequestLogger(next http.Handler) http.Handler {
 	})
 }
 
-func makeGatewayHandler(bs bstore.Blockstore, kuboRPC []string, port int, blockCacheSize int) (*http.Server, error) {
+func makeGatewayHandler(bs bstore.Blockstore, kuboRPC []string, port int, blockCacheSize int, cdns *cachedDNS) (*http.Server, error) {
 	// Sets up an exchange based on the given Block Store
 	exch, err := newExchange(bs)
 	if err != nil {
@@ -60,7 +60,7 @@ func makeGatewayHandler(bs bstore.Blockstore, kuboRPC []string, port int, blockC
 	blockService := blockservice.New(cacheBlockStore, exch)
 
 	// Sets up the routing system, which will proxy the IPNS routing requests to the given gateway.
-	routing := newProxyRouting(kuboRPC)
+	routing := newProxyRouting(kuboRPC, cdns)
 
 	// Creates the gateway with the block service and the routing.
 	gwAPI, err := newBifrostGateway(blockService, routing)

--- a/http_client.go
+++ b/http_client.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type customTransport struct {
+	http.RoundTripper
+	AuthorizationBearerToken string
+}
+
+func (adt *customTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if adt.AuthorizationBearerToken != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", adt.AuthorizationBearerToken))
+	}
+	req.Header.Add("User-Agent", userAgent)
+	return adt.RoundTripper.RoundTrip(req)
+}

--- a/http_client_test.go
+++ b/http_client_test.go
@@ -24,3 +24,24 @@ func TestWithUserAgent(t *testing.T) {
 	_, err := client.Get(ts.URL)
 	assert.Nil(t, err)
 }
+
+func TestWithAuthorizationBearerToken(t *testing.T) {
+	secret := "secret"
+
+	client := &http.Client{
+		Transport: &customTransport{
+			AuthorizationBearerToken: secret,
+			RoundTripper:             http.DefaultTransport,
+		},
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		assert.EqualValues(t, auth, "Bearer "+secret)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	_, err := client.Get(ts.URL)
+	assert.Nil(t, err)
+}

--- a/version.go
+++ b/version.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"net/http"
 	"runtime/debug"
 	"time"
 )
@@ -37,13 +36,4 @@ func buildVersion() string {
 		return day + "-" + revision
 	}
 	return "dev-build"
-}
-
-type withUserAgent struct {
-	http.RoundTripper
-}
-
-func (adt *withUserAgent) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Add("User-Agent", userAgent)
-	return adt.RoundTripper.RoundTrip(req)
 }

--- a/version_test.go
+++ b/version_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestWithUserAgent(t *testing.T) {
 	client := &http.Client{
-		Transport: &withUserAgent{
+		Transport: &customTransport{
 			RoundTripper: http.DefaultTransport,
 		},
 	}


### PR DESCRIPTION
This PR adds support for `STRN_LOGGER_SECRET`. Closes #51 and Closes #43

- When set, requests to `STRN_LOGGER_URL` will be sent with 
  ```
  Authorization: Bearer STRN_LOGGER_SECRET
  ```
- local development works without it, but warning is logged during startup and error is reported in log
- renamed `withUserAgent` to `customTransport` and cleaned up its usage


## TODO

- [x] Weekend

Next week:

- [x] Add regression tests around `Authorization` header
- [x] Sync with @guanzo and  @gmasgras about setting expected `STRN_LOGGER_URL`  `STRN_LOGGER_SECRET` on staging and rollout environments
- [ ] Merge this PR and deploy updated image 