### PR TITLE
feat: run kubo gateway sharness tests

### DIFF
--- a/.github/workflows/gateway-sharness.yml
+++ b/.github/workflows/gateway-sharness.yml
@@ -1,0 +1,55 @@
+name: Gateway Sharness
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: ['main']
+
+jobs:
+  sharness:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19.1
+      - name: Checkout Bifrost Gateway
+        uses: actions/checkout@v3
+        with:
+          path: bifrost
+      - name: Checkout Kubo
+        uses: actions/checkout@v3
+        with:
+          repository: ipfs/kubo
+          ref: feat/sharness-gw-override
+          path: kubo
+      - name: Install Missing Tools
+        run: sudo apt install -y socat net-tools fish libxml2-utils
+      - name: Restore Go Cache
+        uses: protocol/cache-go-action@v1
+        with:
+          name: ${{ github.job }}
+      - name: Install sharness dependencies
+        run: make test_sharness_deps
+        working-directory: kubo
+      - name: Run Bifrost Gateway
+        env:
+          PROXY_GATEWAY_URL: http://127.0.0.1:60080 
+          KUBO_RPC_URL: http://127.0.0.1:60050
+          GOLOG_LOG_LEVEL: error,bifrost-gateway=debug
+        run: |
+          go build -o bifrost-gateway
+          ./bifrost-gateway --gateway-port 8083 &
+          sleep 5s
+        working-directory: bifrost
+      - name: Run Kubo Sharness Tests
+        env:
+          TEST_NODE_GWAY_MADDR: /ip4/127.0.0.1/tcp/60080
+          TEST_NODE_API_MADDR: /ip4/127.0.0.1/tcp/60050
+          TEST_GWAY_MADDR: /ip4/127.0.0.1/tcp/8083
+        run: find . -maxdepth 1 -name "*gateway*.sh" ! -name "*t0400*.sh" ! -name "*t0111*.sh" -type f -print0 | xargs -0 -I {} bash -c "echo {}; {} -v"
+        working-directory: kubo/test/sharness

--- a/gateway.go
+++ b/gateway.go
@@ -32,6 +32,12 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/routing"
 	mc "github.com/multiformats/go-multicodec"
+
+	// Ensure basic codecs are installed.
+	_ "github.com/ipld/go-ipld-prime/codec/cbor"
+	_ "github.com/ipld/go-ipld-prime/codec/dagcbor"
+	_ "github.com/ipld/go-ipld-prime/codec/dagjson"
+	_ "github.com/ipld/go-ipld-prime/codec/json"
 )
 
 type bifrostGateway struct {

--- a/routing.go
+++ b/routing.go
@@ -109,13 +109,13 @@ func (ps *proxyRouting) fetch(ctx context.Context, key string) (rb []byte, err e
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("routing/get RPC returned unexpected status: %s", resp.Status)
-	}
-
 	rb, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("routing/get RPC returned unexpected status: %s, body: %s", resp.Status, string(rb))
 	}
 
 	parts := bytes.Split(bytes.TrimSpace(rb), []byte("\n"))


### PR DESCRIPTION
- [x] Kubo running on unique port.
- [x] Kubo gateway port exported as `PROXY_GATEWAY_URL`
- [x] Bifrost gateway running with `PROXY_GATEWAY_URL`
- [x] Sharness running against Bifrost
	- [x] command line sharness
		- [x] Skip writable gateway tests
		- [x] Skip api-no-gateway
- [ ] See https://github.com/ipfs/kubo/pull/9700