### PR TITLE
fix: ensure (dag)-cbor/json codecs are registered

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -32,6 +32,12 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/routing"
 	mc "github.com/multiformats/go-multicodec"
+
+	// Ensure basic codecs are registered.
+	_ "github.com/ipld/go-ipld-prime/codec/cbor"
+	_ "github.com/ipld/go-ipld-prime/codec/dagcbor"
+	_ "github.com/ipld/go-ipld-prime/codec/dagjson"
+	_ "github.com/ipld/go-ipld-prime/codec/json"
 )
 
 type bifrostGateway struct {


### PR DESCRIPTION
Extracted from #59. Avoids issues when converting codes. This worked out just fine in Kubo because they were already registered in some other point in the code, which was not the case here.