### PR TITLE
ci: add gateway-confromance test suite to the CI

### DIFF
--- a/.github/workflows/gateway-conformance.yml
+++ b/.github/workflows/gateway-conformance.yml
@@ -52,6 +52,7 @@ jobs:
           xml: output.xml
           html: output.html
           markdown: output.md
+          specs: -subdomain-gateway
 
       # 7. Upload the results
       - name: Upload MD summary

--- a/.github/workflows/gateway-conformance.yml
+++ b/.github/workflows/gateway-conformance.yml
@@ -2,6 +2,9 @@ name: Gateway Conformance
 
 on:
   push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   gateway-conformance:

--- a/.github/workflows/gateway-conformance.yml
+++ b/.github/workflows/gateway-conformance.yml
@@ -1,0 +1,65 @@
+name: Gateway Conformance
+
+on:
+  push:
+
+jobs:
+  gateway-conformance:
+    runs-on: ubuntu-latest
+    steps:
+      # 1. Start the Kubo gateway
+      - name: Download Kubo gateway
+        uses: ipfs/download-ipfs-distribution-action@v1
+      - name: Start Kubo gateway
+        uses: ipfs/start-ipfs-daemon-action@v1
+
+      # 2. Download the gateway-conformance fixtures
+      - name: Download gateway-conformance fixtures
+        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@main
+        with:
+          output: fixtures
+
+      # 3. Populate the Kubo gateway with the gateway-conformance fixtures
+      - name: Import fixtures
+        run: find ./fixtures -name '*.car' -exec ipfs dag import {} \;
+
+      # 4. Build the bifrost-gateway
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19.x
+      - name: Checkout bifrost-gateway
+        uses: actions/checkout@v3
+        with:
+          path: bifrost-gateway
+      - name: Build bifrost-gateway
+        run: go build
+        working-directory: bifrost-gateway
+
+      # 5. Start the bifrost-gateway
+      - name: Start bifrost-gateway
+        env:
+          PROXY_GATEWAY_URL: http://127.0.0.1:8080
+        run: ./bifrost-gateway &
+        working-directory: bifrost-gateway
+
+      # 6. Run the gateway-conformance tests
+      - name: Run gateway-conformance tests
+        uses: ipfs/gateway-conformance/.github/actions/test@main
+        with:
+          gateway-url: http://127.0.0.1:8081
+          json: output.json
+          xml: output.xml
+          html: output.html
+          markdown: output.md
+
+      # 7. Upload the results
+      - name: Upload MD summary
+        if: failure() || success()
+        run: cat output.md >> $GITHUB_STEP_SUMMARY
+      - name: Upload HTML report
+        if: failure() || success()
+        uses: actions/upload-artifact@v3
+        with:
+          name: gateway-conformance.html
+          path: output.html

--- a/.github/workflows/gateway-conformance.yml
+++ b/.github/workflows/gateway-conformance.yml
@@ -15,7 +15,8 @@ jobs:
 
       # 2. Download the gateway-conformance fixtures
       - name: Download gateway-conformance fixtures
-        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@main
+        # TODO: use a release tag once https://github.com/ipfs/gateway-conformance/pull/19 is merged
+        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@e320c2b1f576f69732d824c4d48a1c37bb0ad320
         with:
           output: fixtures
 
@@ -45,7 +46,8 @@ jobs:
 
       # 6. Run the gateway-conformance tests
       - name: Run gateway-conformance tests
-        uses: ipfs/gateway-conformance/.github/actions/test@main
+        # TODO: use a release tag once https://github.com/ipfs/gateway-conformance/pull/19 is merged
+        uses: ipfs/gateway-conformance/.github/actions/test@e320c2b1f576f69732d824c4d48a1c37bb0ad320
         with:
           gateway-url: http://127.0.0.1:8081
           json: output.json

--- a/.github/workflows/gateway-conformance.yml
+++ b/.github/workflows/gateway-conformance.yml
@@ -53,6 +53,7 @@ jobs:
           html: output.html
           markdown: output.md
           specs: -subdomain-gateway
+          args: -skip TestGatewayCar
 
       # 7. Upload the results
       - name: Upload MD summary


### PR DESCRIPTION
This PR adds https://github.com/ipfs/gateway-conformance to the CI here.

We set up Kubo backed bifrost-gateway for the tests.

We keep `subdomain-gateway` spec testing disabled because: https://github.com/ipfs/bifrost-gateway/actions/runs/4511354942
We keep `TestGatewayCar` disabled because: https://github.com/ipfs/bifrost-gateway/actions/runs/4511433301

References to `ipfs/gateway-conformance` will be replaced with proper release tags once we have any (i.e. once we have release process set up - https://github.com/ipfs/gateway-conformance/pull/19).