### PR TITLE
ci: enable subdomain testing

### DIFF
--- a/.github/workflows/gateway-conformance.yml
+++ b/.github/workflows/gateway-conformance.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Start bifrost-gateway
         env:
           PROXY_GATEWAY_URL: http://127.0.0.1:8080
+          GATEWAY_CONFORMANCE_TEST: true
         run: ./bifrost-gateway &
         working-directory: bifrost-gateway
 
@@ -57,7 +58,6 @@ jobs:
           xml: output.xml
           html: output.html
           markdown: output.md
-          specs: -subdomain-gateway
           args: -skip TestGatewayCar
 
       # 7. Upload the results

--- a/handlers.go
+++ b/handlers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
+	"os"
 	"strconv"
 	"time"
 
@@ -94,6 +95,15 @@ func makeGatewayHandler(bs bstore.Blockstore, kuboRPC []string, port int, blockC
 			NoDNSLink:     noDNSLink,
 			UseSubdomains: true,
 		},
+	}
+
+	// If we're doing tests, ensure the right public gateways are enabled.
+	if os.Getenv("GATEWAY_CONFORMANCE_TEST") == "true" {
+		publicGateways["example.com"] = &gateway.Specification{
+			Paths:         []string{"/ipfs", "/ipns"},
+			NoDNSLink:     noDNSLink,
+			UseSubdomains: true,
+		}
 	}
 
 	// Creates metrics handler for total response size. Matches the same metrics


### PR DESCRIPTION
Enables the subdomain conformance tests. For this I had to add a environmental variable, so that we can configure the right subdomain to "listen on". In addition, I had to add support for `CONNECT` for the proxy tunneling to work.