### PR TITLE
fix: single byte range prefetch

### DIFF
--- a/lib/graph_gateway.go
+++ b/lib/graph_gateway.go
@@ -345,18 +345,16 @@ func (api *GraphGateway) Get(ctx context.Context, path gateway.ImmutablePath, by
 	carParams := "?format=car&depth=1"
 
 	// fetch CAR with &bytes= to get minimal set of blocks for the request
+	// Note: majority of requests have 0 or max 1 ranges. if there are more ranges than one,
+	// that is a niche edge cache we don't prefetch as CAR and use fallback blockstore instead.
 	if rangeCount > 0 {
 		bytesBuilder := strings.Builder{}
 		bytesBuilder.WriteString("&bytes=")
-		for i, r := range byteRanges {
-			bytesBuilder.WriteString(strconv.FormatUint(r.From, 10))
-			bytesBuilder.WriteString("-")
-			if r.To != nil {
-				bytesBuilder.WriteString(strconv.FormatInt(*r.To, 10))
-			}
-			if i != rangeCount-1 {
-				bytesBuilder.WriteString(",")
-			}
+		r := byteRanges[0]
+		bytesBuilder.WriteString(strconv.FormatUint(r.From, 10))
+		bytesBuilder.WriteString(":")
+		if r.To != nil {
+			bytesBuilder.WriteString(strconv.FormatInt(*r.To, 10))
 		}
 		carParams += bytesBuilder.String()
 	}


### PR DESCRIPTION
This is a quick follow-up fix for #61.

Seems there is no agreement on supporting more than one byte range. This will only prefetch the first range as CAR, and use block-by-block for remaining ones.

In practice, we don't expect to see more than a single range in the real world, video seeking creates a single one etc.

(Merging so staging is ready and will show improved graphs once the other end deploys it.)