### PR TITLE
fix: panic  + wider histograms

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/filecoin-saturn/caboose v0.0.0-20230405181410-e4b1e88476d9
 	github.com/gogo/protobuf v1.3.2
 	github.com/hashicorp/golang-lru/v2 v2.0.1
-	github.com/ipfs/boxo v0.8.1-0.20230405204336-6e1d7a4d43f7
+	github.com/ipfs/boxo v0.8.1-0.20230406132331-999d939e84a0
 	github.com/ipfs/go-block-format v0.1.2
 	github.com/ipfs/go-cid v0.4.0
 	github.com/ipfs/go-ipld-format v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -193,8 +193,8 @@ github.com/influxdata/tdigest v0.0.1 h1:XpFptwYmnEKUqmkcDjrzffswZ3nvNeevbUSLPP/Z
 github.com/influxdata/tdigest v0.0.1/go.mod h1:Z0kXnxzbTC2qrx4NaIzYkE1k66+6oEDQTvL95hQFh5Y=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/boxo v0.8.1-0.20230405204336-6e1d7a4d43f7 h1:MjuhON7F6hTdY8wDVD86/Kbb05rsbm9EC9yVZ8dlbpM=
-github.com/ipfs/boxo v0.8.1-0.20230405204336-6e1d7a4d43f7/go.mod h1:RIsi4CnTyQ7AUsNn5gXljJYZlQrHBMnJp94p73liFiA=
+github.com/ipfs/boxo v0.8.1-0.20230406132331-999d939e84a0 h1:iMQs+Totmzajpm5zlzuqEDuvnQ/lvUcAwmr3W0Xo6Bk=
+github.com/ipfs/boxo v0.8.1-0.20230406132331-999d939e84a0/go.mod h1:RIsi4CnTyQ7AUsNn5gXljJYZlQrHBMnJp94p73liFiA=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=
 github.com/ipfs/go-bitfield v1.1.0/go.mod h1:paqf1wjq/D2BBmzfTVFlJQ9IlFOZpg422HL0HqsGWHU=
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=


### PR DESCRIPTION
Includes commits from boxo main branch:
https://github.com/ipfs/boxo/pull/265
https://github.com/ipfs/boxo/pull/272

Closes https://github.com/ipfs/bifrost-gateway/issues/77