### PR TITLE
chore: release 0.0.2

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": ""
+  "version": "v0.0.2"
 }


### PR DESCRIPTION
Tagging release  so we can deploy to prod

- `GRAPH_BACKEND` is `false` by default, so _should_ have no impact on metrics
  - Still, Graph API required us to refactor a lot of code. 
  - There is slight risk that changes made to caboose OR boxo/gateway refactor will impact correctness/latency, but we can't do much about it – worst case, will revert prod to 0.0.1
- Might help with the [‘problem’ with the Frankfurt hosts](https://www.notion.so/bifrost-bank1-fr-is-causing-overall-correctness-to-be-far-worse-c0d24546307d4fb39ac052852e9efa23) which have symptom of a memleak – if it still happens after upgrading to latest version (has both our updates + switch to go 0.20.3), means we need to investigate