### PR TITLE
Re-enable http/2

### DIFF
--- a/blockstore_caboose.go
+++ b/blockstore_caboose.go
@@ -10,6 +10,7 @@ import (
 	"github.com/filecoin-saturn/caboose"
 	blockstore "github.com/ipfs/boxo/blockstore"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"golang.org/x/net/http2"
 )
 
 const (
@@ -60,32 +61,41 @@ func newCabooseBlockStore(orchestrator, loggingEndpoint string, cdns *cachedDNS)
 		},
 	}
 
+	saturnTransport := http.Transport{
+		// Increasing concurrency defaults from http.DefaultTransport
+		MaxIdleConns:        1000,
+		MaxConnsPerHost:     100,
+		MaxIdleConnsPerHost: 100,
+		IdleConnTimeout:     90 * time.Second,
+
+		DialContext: cdns.dialWithCachedDNS,
+
+		// Saturn Weltschmerz
+		TLSClientConfig: &tls.Config{
+			// Saturn use TLS in controversial ways, which sooner or
+			// later will force them to switch away to different domain
+			// name and certs, in which case they will break us. Since
+			// we are fetching raw blocks and dont really care about
+			// TLS cert being legitimate, let's disable verification
+			// to save CPU and to avoid catastrophic failure when
+			// Saturn L1s suddenly switch to certs with different DNS name.
+			InsecureSkipVerify: true,
+			// ServerName:         "strn.pl",
+		},
+	}
+
+	saturnWithH2, err := http2.ConfigureTransports(&saturnTransport)
+	if err != nil {
+		return nil, err
+	}
+
+	saturnRoundTripper := otelhttp.NewTransport(&customTransport{
+		RoundTripper: saturnWithH2,
+	})
+
 	saturnRetrievalClient := &http.Client{
-		Timeout: caboose.DefaultSaturnCarRequestTimeout,
-		Transport: otelhttp.NewTransport(&customTransport{
-			RoundTripper: &http.Transport{
-				// Increasing concurrency defaults from http.DefaultTransport
-				MaxIdleConns:        1000,
-				MaxConnsPerHost:     100,
-				MaxIdleConnsPerHost: 100,
-				IdleConnTimeout:     90 * time.Second,
-
-				DialContext: cdns.dialWithCachedDNS,
-
-				// Saturn Weltschmerz
-				TLSClientConfig: &tls.Config{
-					// Saturn use TLS in controversial ways, which sooner or
-					// later will force them to switch away to different domain
-					// name and certs, in which case they will break us. Since
-					// we are fetching raw blocks and dont really care about
-					// TLS cert being legitimate, let's disable verification
-					// to save CPU and to avoid catastrophic failure when
-					// Saturn L1s suddenly switch to certs with different DNS name.
-					InsecureSkipVerify: true,
-					// ServerName:         "strn.pl",
-				},
-			},
-		}),
+		Timeout:   caboose.DefaultSaturnCarRequestTimeout,
+		Transport: saturnRoundTripper,
 	}
 
 	return caboose.NewCaboose(&caboose.Config{

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	go.uber.org/atomic v1.10.0
 	go.uber.org/multierr v1.9.0
 	go.uber.org/zap v1.24.0
+	golang.org/x/net v0.7.0
 )
 
 require (
@@ -164,7 +165,6 @@ require (
 	golang.org/x/crypto v0.6.0 // indirect
 	golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb // indirect
 	golang.org/x/mod v0.7.0 // indirect
-	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/text v0.7.0 // indirect


### PR DESCRIPTION
By setting a custom TLSClientConfig we remove the default of having a `NextProtos` set and need to add it back