### PR TITLE
fix: ForceAttemptHTTP2 despite custom TLSClientConfig

### DIFF
--- a/blockstore_caboose.go
+++ b/blockstore_caboose.go
@@ -84,6 +84,7 @@ func newCabooseBlockStore(orchestrator, loggingEndpoint string, cdns *cachedDNS)
 					InsecureSkipVerify: true,
 					// ServerName:         "strn.pl",
 				},
+				ForceAttemptHTTP2: true,
 			},
 		}),
 	}

--- a/blockstore_caboose.go
+++ b/blockstore_caboose.go
@@ -45,7 +45,8 @@ func newCabooseBlockStore(orchestrator, loggingEndpoint string, cdns *cachedDNS)
 		Timeout: caboose.DefaultSaturnOrchestratorRequestTimeout,
 		Transport: &customTransport{
 			RoundTripper: &http.Transport{
-				DialContext: cdns.dialWithCachedDNS,
+				DialContext:       cdns.dialWithCachedDNS,
+				ForceAttemptHTTP2: true,
 			},
 		},
 	}
@@ -55,7 +56,8 @@ func newCabooseBlockStore(orchestrator, loggingEndpoint string, cdns *cachedDNS)
 		Transport: &customTransport{
 			AuthorizationBearerToken: os.Getenv(EnvSaturnLoggerSecret),
 			RoundTripper: &http.Transport{
-				DialContext: cdns.dialWithCachedDNS,
+				DialContext:       cdns.dialWithCachedDNS,
+				ForceAttemptHTTP2: true,
 			},
 		},
 	}

--- a/blockstore_proxy.go
+++ b/blockstore_proxy.go
@@ -84,6 +84,7 @@ func newProxyBlockStore(gatewayURL []string, cdns *cachedDNS) blockstore.Blockst
 					MaxIdleConnsPerHost: 100,
 					IdleConnTimeout:     90 * time.Second,
 					DialContext:         cdns.dialWithCachedDNS,
+					ForceAttemptHTTP2:   true,
 				},
 			}),
 		},

--- a/routing.go
+++ b/routing.go
@@ -44,6 +44,7 @@ func newProxyRouting(kuboRPC []string, cdns *cachedDNS) routing.ValueStore {
 					MaxIdleConnsPerHost: 100,
 					IdleConnTimeout:     90 * time.Second,
 					DialContext:         cdns.dialWithCachedDNS,
+					ForceAttemptHTTP2:   true,
 				},
 			}),
 		},


### PR DESCRIPTION
By setting `ForceAttemptHTTP2`