### PR TITLE
Revert "Enable HTTP1"

### DIFF
--- a/blockstore_caboose.go
+++ b/blockstore_caboose.go
@@ -67,9 +67,9 @@ func newCabooseBlockStore(orchestrator, loggingEndpoint string, cdns *cachedDNS)
 		Transport: otelhttp.NewTransport(&customTransport{
 			RoundTripper: &http.Transport{
 				// Increasing concurrency defaults from http.DefaultTransport
-				MaxIdleConns:        200000,
-				MaxConnsPerHost:     20000,
-				MaxIdleConnsPerHost: 20000,
+				MaxIdleConns:        1000,
+				MaxConnsPerHost:     100,
+				MaxIdleConnsPerHost: 100,
 				IdleConnTimeout:     90 * time.Second,
 
 				DialContext: cdns.dialWithCachedDNS,
@@ -86,7 +86,7 @@ func newCabooseBlockStore(orchestrator, loggingEndpoint string, cdns *cachedDNS)
 					InsecureSkipVerify: true,
 					// ServerName:         "strn.pl",
 				},
-				ForceAttemptHTTP2: false,
+				ForceAttemptHTTP2: true,
 			},
 		}),
 	}


### PR DESCRIPTION
Reverts ipfs/bifrost-gateway#114

I don't know if we have staging still configured to only send queries back to a single node at the moment though