### PR TITLE
return from subscription when closed

### DIFF
--- a/lib/pubsub.go
+++ b/lib/pubsub.go
@@ -2,8 +2,9 @@ package lib
 
 import (
 	"context"
-	"github.com/multiformats/go-multihash"
 	"sync"
+
+	"github.com/multiformats/go-multihash"
 
 	pubsub "github.com/cskr/pubsub"
 	blocks "github.com/ipfs/go-block-format"
@@ -113,6 +114,7 @@ func (ps *impl) Subscribe(ctx context.Context, keys ...multihash.Multihash) <-ch
 			case <-ctx.Done():
 				return
 			case <-ps.closed:
+				return
 			case val, ok := <-valuesCh:
 				if !ok {
 					return
@@ -126,6 +128,7 @@ func (ps *impl) Subscribe(ctx context.Context, keys ...multihash.Multihash) <-ch
 					return
 				case blocksCh <- block: // continue
 				case <-ps.closed:
+					return
 				}
 			}
 		}


### PR DESCRIPTION
Curious to see if this changes semantics.

* block requests will be [waiting](https://github.com/ipfs/bifrost-gateway/blob/main/lib/graph_gateway.go#L684) on this subscription
* the way that subscription seems meant to be terminated is via call to [close](https://github.com/ipfs/bifrost-gateway/blob/main/lib/graph_gateway.go#L382) which leads to a shutdown of the pubsub.