### PR TITLE
Disable caboose correctness policy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/cskr/pubsub v1.0.2
-	github.com/filecoin-saturn/caboose v0.0.2-0.20230531112055-7e5dc316707b
+	github.com/filecoin-saturn/caboose v0.0.1-disable-caboose-correctness
 	github.com/gogo/protobuf v1.3.2
 	github.com/hashicorp/golang-lru/v2 v2.0.1
 	github.com/ipfs/boxo v0.8.2-0.20230529195554-b8b39bea7728

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/cskr/pubsub v1.0.2
-	github.com/filecoin-saturn/caboose v0.0.2-0.20230531105917-c163a49b9c9c
+	github.com/filecoin-saturn/caboose v0.0.2-0.20230531112055-7e5dc316707b
 	github.com/gogo/protobuf v1.3.2
 	github.com/hashicorp/golang-lru/v2 v2.0.1
 	github.com/ipfs/boxo v0.8.2-0.20230529195554-b8b39bea7728

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/cskr/pubsub v1.0.2
-	github.com/filecoin-saturn/caboose v0.0.1
+	github.com/filecoin-saturn/caboose v0.0.2-0.20230531105917-c163a49b9c9c
 	github.com/gogo/protobuf v1.3.2
 	github.com/hashicorp/golang-lru/v2 v2.0.1
 	github.com/ipfs/boxo v0.8.2-0.20230529195554-b8b39bea7728

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/felixge/httpsnoop v1.0.0/go.mod h1:3+D9sFq0ahK/JeJPhCBUV1xlf4/eIYrUQaxulT0VzX8=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/filecoin-saturn/caboose v0.0.1 h1:2Er99712QtA6m25GZk5hzjE/koQptgvF/3a3QGRGQfM=
-github.com/filecoin-saturn/caboose v0.0.1/go.mod h1:GXoJEZYUzvoWrsRxsBtl94Ltjl+uzIrhpkK2+QtDM90=
+github.com/filecoin-saturn/caboose v0.0.2-0.20230531105917-c163a49b9c9c h1:4LkI4k8KYCsOIlJAswvC97g7UYyexvThYYpQyoCFYRk=
+github.com/filecoin-saturn/caboose v0.0.2-0.20230531105917-c163a49b9c9c/go.mod h1:GXoJEZYUzvoWrsRxsBtl94Ltjl+uzIrhpkK2+QtDM90=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=
 github.com/flynn/noise v1.0.0/go.mod h1:xbMo+0i6+IGbYdJhF31t2eR1BIU0CYc12+BNAKwUTag=

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/felixge/httpsnoop v1.0.0/go.mod h1:3+D9sFq0ahK/JeJPhCBUV1xlf4/eIYrUQaxulT0VzX8=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/filecoin-saturn/caboose v0.0.2-0.20230531105917-c163a49b9c9c h1:4LkI4k8KYCsOIlJAswvC97g7UYyexvThYYpQyoCFYRk=
-github.com/filecoin-saturn/caboose v0.0.2-0.20230531105917-c163a49b9c9c/go.mod h1:GXoJEZYUzvoWrsRxsBtl94Ltjl+uzIrhpkK2+QtDM90=
+github.com/filecoin-saturn/caboose v0.0.2-0.20230531112055-7e5dc316707b h1:3K/uvrg8B6brA67uapfP98wfHZj78SJcrSeWRm2CblA=
+github.com/filecoin-saturn/caboose v0.0.2-0.20230531112055-7e5dc316707b/go.mod h1:GXoJEZYUzvoWrsRxsBtl94Ltjl+uzIrhpkK2+QtDM90=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=
 github.com/flynn/noise v1.0.0/go.mod h1:xbMo+0i6+IGbYdJhF31t2eR1BIU0CYc12+BNAKwUTag=

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/felixge/httpsnoop v1.0.0/go.mod h1:3+D9sFq0ahK/JeJPhCBUV1xlf4/eIYrUQaxulT0VzX8=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/filecoin-saturn/caboose v0.0.2-0.20230531112055-7e5dc316707b h1:3K/uvrg8B6brA67uapfP98wfHZj78SJcrSeWRm2CblA=
-github.com/filecoin-saturn/caboose v0.0.2-0.20230531112055-7e5dc316707b/go.mod h1:GXoJEZYUzvoWrsRxsBtl94Ltjl+uzIrhpkK2+QtDM90=
+github.com/filecoin-saturn/caboose v0.0.1-disable-caboose-correctness h1:Li4hyx8Zj5xcx92AJRuH/sFQ3GbEX8Trc60F9gSsQzw=
+github.com/filecoin-saturn/caboose v0.0.1-disable-caboose-correctness/go.mod h1:GXoJEZYUzvoWrsRxsBtl94Ltjl+uzIrhpkK2+QtDM90=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=
 github.com/flynn/noise v1.0.0/go.mod h1:xbMo+0i6+IGbYdJhF31t2eR1BIU0CYc12+BNAKwUTag=

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.0.8"
+  "version": "v0.0.9"
 }


### PR DESCRIPTION
Waiting for results from staging over the next hour after deploying the same commit to staging:

```
docker logs d7f7ad889b2f
Changing user to ipfs
bifrost-gateway version 2023-05-31-e3e26df
2023/05/31 11:33:47 Starting bifrost-gateway 2023-05-31-e3e26df
2023/05/31 11:33:47 Saturn backend (STRN_ORCHESTRATOR_URL) at https://orchestrator.strn.pl/nodes/nearby?count=100
2023/05/31 11:33:47 Saturn logger  (STRN_LOGGER_URL) at https://twb3qukm2i654i3tnvx36char40aymqq.lambda-url.us-west-2.on.aws
2023/05/31 11:33:47 BLOCK_CACHE_SIZE: 16384
2023/05/31 11:33:47 GRAPH_BACKEND: true
2023/05/31 11:33:47 Legacy RPC at /api/v0 (KUBO_RPC_URL) provided by https://node0.delegate.ipfs.io https://node1.delegate.ipfs.io https://node2.delegate.ipfs.io https://node3.delegate.ipfs.io
2023/05/31 11:33:47 Path gateway listening on http://127.0.0.1:8081
2023/05/31 11:33:47   Smoke test (JPG): http://127.0.0.1:8081/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi
2023/05/31 11:33:47 Subdomain gateway configured on dweb.link and http://localhost:8081
2023/05/31 11:33:47 Metrics exposed at http://127.0.0.1:8041/debug/metrics/prometheus
2023/05/31 11:33:47   Smoke test (Subdomain+DNSLink+UnixFS+HAMT): http://localhost:8081/ipns/en.wikipedia-on-ipfs.org/wiki/

```


Caboose diff compared to `v0.0.1`(which is what currently runs in Bifrost prod) AT https://github.com/filecoin-saturn/caboose/compare/v0.0.1...fix/caboose-disable-correctness?expand=1

https://github.com/filecoin-saturn/caboose/compare/v0.0.1...v0.0.1-disable-caboose-correctness


