### PR TITLE
handle block before checking err

### DIFF
--- a/lib/graph_gateway.go
+++ b/lib/graph_gateway.go
@@ -359,20 +359,20 @@ func (api *GraphGateway) loadRequestIntoSharedBlockstoreAndBlocksGateway(ctx con
 				case <-t.C:
 					return gateway.ErrGatewayTimeout
 				}
-				if !ok || err != nil {
-					if errors.Is(err, io.EOF) {
-						return nil
-					}
-					return err
-				}
 				if blk != nil {
 					if err := bstore.Put(ctx, blk); err != nil {
 						return err
 					}
 					metrics.carBlocksFetchedMetric.Inc()
 					api.notifyOngoingRequests(ctx, notifierKey, blk)
-				} else {
+				} else if ok {
 					graphLog.Errorw("got nil block from car reader", "path", path, "ok", ok, "err", err)
+				}
+				if !ok || err != nil {
+					if errors.Is(err, io.EOF) {
+						return nil
+					}
+					return err
 				}
 			}
 		})


### PR DESCRIPTION
Fixes race condition where:

1. Last block in CAR is assigned to `blk`
https://github.com/ipfs/bifrost-gateway/blob/ad571e67e001c71019448831eac93079431fc50b/lib/graph_gateway.go#L336
2. Next call to `cr.Next()` assigns `EOF` to `err`
https://github.com/ipfs/bifrost-gateway/blob/ad571e67e001c71019448831eac93079431fc50b/lib/graph_gateway.go#L336-L339
3. At this point, both `blk` and `err` have a truthy value. `blk` needs to be put in the block store, but `err` is checked first. So the function returns without putting the last block in.
https://github.com/ipfs/bifrost-gateway/blob/ad571e67e001c71019448831eac93079431fc50b/lib/graph_gateway.go#L362-L376