### PR TITLE
return once car reader errors

### DIFF
--- a/lib/graph_gateway.go
+++ b/lib/graph_gateway.go
@@ -336,6 +336,7 @@ func (api *GraphGateway) loadRequestIntoSharedBlockstoreAndBlocksGateway(ctx con
 					blk, rdErr := cr.Next()
 					if rdErr != nil {
 						err = rdErr
+						return
 					}
 					select {
 					case blkCh <- blk:


### PR DESCRIPTION
I believe this fixes the recent `use of closed network connection` error spike that first appeared a day ago on 2023-05-30 15:00:00 UTC, seen on this dashboard. https://protocollabs.grafana.net/d/mdJkp5YVz/caboose-l1-metrics?orgId=1&from=now-2d&to=now&var-interval=5m&var-Environment=production&var-node_id=All&viewPanel=52

The error timing correlates with this deploy https://github.com/protocol/bifrost-infra/pull/2570, which was the first deploy of this commit https://github.com/ipfs/bifrost-gateway/commit/c952ddbd71b69fd535702469fff4bb0764cb0fcb

It's hard to reproduce consistently but once you send enough requests it manifests. Here's some ugly logs

```
---car.NewCarReader rdErr------- context canceled <nil>
--Send block to blkCh-- <nil>
---car.NewCarReader rdErr------- read tcp 127.0.0.1:54322->127.0.0.1:443: use of closed network connection <nil>
-------<-cbCtx.Done(). closing blkCh-------
```

which correspond to this modified function https://github.com/ipfs/bifrost-gateway/blob/067d77b68c3f93b314c04526583f28215cc0a3e7/lib/graph_gateway.go#L333

```go
	go func() {
		defer close(blkCh)
		for {
			blk, rdErr := cr.Next()
			if rdErr != nil {
				fmt.Println("---car.NewCarReader rdErr-------", rdErr, blk)
				err = rdErr
				//return
			} else {
				fmt.Printf("--block from car.NewCarReader-----%v %v---\n", blk.Cid(), len(blk.RawData()))
			}
			select {
			case blkCh <- blk:
				fmt.Println("--Send block to blkCh--",blk)
			case <-cbCtx.Done():
				fmt.Println("-------<-cbCtx.Done(). closing blkCh-------")
				return
			}
		}
	}()
```

It tries to read from the car reader after it returns an error. Even if my diagnosis is wrong, there's no harm in returning in this case right?