### PR TITLE
handoffExchange checks shared blockstore right before falling back to block requests

### DIFF
--- a/lib/graph_gateway.go
+++ b/lib/graph_gateway.go
@@ -781,7 +781,7 @@ func (f *handoffExchange) GetBlocks(ctx context.Context, cids []cid.Cid) (<-chan
 							case retCh <- blk:
 								cs.Add(blk.Cid())
 							case <-ctx.Done():
-							    return
+								return
 							}
 						} else {
 							newCidArr = append(newCidArr, c)

--- a/lib/graph_gateway.go
+++ b/lib/graph_gateway.go
@@ -777,8 +777,12 @@ func (f *handoffExchange) GetBlocks(ctx context.Context, cids []cid.Cid) (<-chan
 					if !cs.Has(c) {
 						blk, _ := f.bstore.Get(ctx, c)
 						if blk != nil {
-							retCh <- blk
-							cs.Add(blk.Cid())
+							select {
+							case retCh <- blk:
+								cs.Add(blk.Cid())
+							case <-ctx.Done():
+							    return
+							}
 						} else {
 							newCidArr = append(newCidArr, c)
 						}


### PR DESCRIPTION
There are various race conditions with pubsub that prevent blocks from being propagated to subscribers.

1. The CAR read finishes and publishes the last few blocks. At the same time, the pubsub instance shuts down because the CAR fetch is done. 

Because `select` chooses a random `case` if multiple are ready, it's possible to choose the `<-ps.closed` case and return, even if `valuesCh` has pending values. We could ensure that the `valuesCh` channel is drained before returning, but let's examine more race conditions.

https://github.com/ipfs/bifrost-gateway/blob/83f1b6f3ddd3e6f24120dc2015c5d1559f4cbb05/lib/pubsub.go#L112-L133

2. It's rare, but the finalizer will delete the notifier before the CAR read is done, which prevents block publishes
https://github.com/ipfs/bifrost-gateway/blob/83f1b6f3ddd3e6f24120dc2015c5d1559f4cbb05/lib/graph_gateway.go#L522

3. Also rare, but sometimes blocks arrive before the subscription is even setup, meaning there's nothing to publish to. That would require an extremely fast download that might only occur if bifrost is downloading a cached file from a localhost L1.

Proposal: Check the blockstore right before the fallback logic is run. The fallback logic runs after the CAR fetch is done. So if the fetch completed successfully, then the blockstore will have the missing blocks. Otherwise, continue the fallback. This sidesteps all the pubsub race conditions.