### PR TITLE
re-enable http2

### DIFF
--- a/blockstore_caboose.go
+++ b/blockstore_caboose.go
@@ -86,7 +86,7 @@ func newCabooseBlockStore(orchestrator, loggingEndpoint string, cdns *cachedDNS)
 					InsecureSkipVerify: true,
 					// ServerName:         "strn.pl",
 				},
-				ForceAttemptHTTP2: false,
+				ForceAttemptHTTP2: true,
 			},
 		}),
 	}


### PR DESCRIPTION
Now that parameters are tuned and car's aren't timing out this should be safe to re-enable.