### PR TITLE
limiter to prevent oom

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.14.0
 	go.uber.org/atomic v1.10.0
 	go.uber.org/zap v1.24.0
+	golang.org/x/sync v0.1.0
 )
 
 require (
@@ -172,7 +173,6 @@ require (
 	golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb // indirect
 	golang.org/x/mod v0.7.0 // indirect
 	golang.org/x/net v0.7.0 // indirect
-	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	golang.org/x/tools v0.5.0 // indirect


### PR DESCRIPTION
temporary attempt at identifying where the OOM is.

There are not so many requests presently to make it clear why staging is repeatedly running out of memory.

This limits how many active requests/ caches are allowed, to see if the issue is that there are enough 'large' requests that end up stacking concurrently to cause the issue.