### PR TITLE
fix(docker): segfault in su-exec, pin busybox image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o $GOPATH/bin/bifrost-gateway
 
 
 #------------------------------------------------------
-FROM --platform=${BUILDPLATFORM:-linux/amd64} busybox:1-glibc
+FROM --platform=${BUILDPLATFORM:-linux/amd64} busybox:1.34.1-glibc
 MAINTAINER IPFS Stewards <w3dt-stewards-ip@protocol.ai>
 
 ENV GOPATH                 /go


### PR DESCRIPTION
`busybox:1-glibc` got updated yesterday and now `su-exec` used in `entrypoint.sh` segfaults. 

This PR is pinning busybox to older, working version – a quick fix to make sure Docker images are usable.


## Appendix: how it got debugged

Staging is  in a reboot loop:

```console
$ docker logs -f bifrost-gw
Changing user to ipfs
Changing user to ipfs
Changing user to ipfs
Changing user to ipfs
Changing user to ipfs
Changing user to ipfs
Changing user to ipfs
Changing user to ipfs
```

I get the same error with ipfs/bifrost-gateway:staging-latest image:

```console
$ docker pull ipfs/bifrost-gateway:staging-latest
[..]
Digest: sha256:889567909465aa8abc55ed5f3ad7285b945c0b2efbbc432dacf758a03e2c6807 

$ docker run --rm -it --net=host -e STRN_ORCHESTRATOR_URL="https://orchestrator.strn.pl/nodes/nearby?count=1000" -e GRAPH_BACKEND=true ipfs/bifrost-gateway:staging-latest

Changing user to ipfs
[exit code 139]
```

golang binary produces 139 on segfault or some other low level issue.

if I build staging image for  b9cd916 myself, there is no problem:

```console
$ docker build -t bifrost-gateway-test . && docker run --rm -it --net=host -e STRN_ORCHESTRATOR_URL="https://orchestrator.strn.pl/nodes/nearby?count=1000" -e GRAPH_BACKEND=true bifrost-gateway-test

Changing user to ipfs
bifrost-gateway version 2023-06-29-b9cd916
```

so its something with the Docker image ipfs/bifrost-gateway:staging-latest specifically.  it crashes even before it prints version, and we explicitly run bifrost-gateway --version before the real run just to catch quirks like this one.

If i replace Docker  entrypoint with sh i can run the bifrost-gateway manually just fine, so its unrelated to your changes --  it is    su-exec  in entrypoint.sh that fails and that is what returns 139.

Conformed this in `docker run --rm -it --net=host  --entrypoint /bin/sh ipfs/bifrost-gateway:staging-latest`

```console
/ # su-exec ipfs bifrost-gateway --version
Segmentation fault
```

Could because by change in golang:1.20-bullseye or busybox:1-glibc base images, the latter changed yesterday and i confirmed that switching to previous one 1.34.1-glibc made problem go away.

:point_right:  So the fix is to update Dockerfile and switch base images to point at specific, working versions until  its resolved upstream by aligning glibcs across both base images.

### Takeways

Also, a lesson here is that if a "rolling" tag is used, the build can break due to external changes.
I've kept golang image to be rolling, so we get security patches automatically, but we should keep glibc busybox pinned for now.