### PR TITLE
refactor(docker): simplify Dockerfile, fix arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,67 +1,46 @@
 FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.20-bullseye AS builder
-MAINTAINER IPFS Stewards <w3dt-stewards-ip@protocol.ai>
+# This builds bifrost-gateway
 
-# This dockerfile builds and runs bifrost-gateway
-
-ARG TARGETPLATFORM
-ARG BUILDPLATFORM
-ARG TARGETOS
-ARG TARGETARCH
+ARG TARGETPLATFORM TARGETOS TARGETARCH
 
 ENV GOPATH      /go
 ENV SRC_PATH    $GOPATH/src/github.com/ipfs/bifrost-gateway
 ENV GO111MODULE on
 ENV GOPROXY     https://proxy.golang.org
 
-ENV SUEXEC_VERSION v0.2
-ENV TINI_VERSION v0.19.0
-RUN set -eux; \
-    dpkgArch="$(dpkg --print-architecture)"; \
-    case "${dpkgArch##*-}" in \
-        "amd64" | "armhf" | "arm64") tiniArch="tini-static-$dpkgArch" ;;\
-        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
-    esac; \
-  cd /tmp \
-  && git clone https://github.com/ncopa/su-exec.git \
-  && cd su-exec \
-  && git checkout -q $SUEXEC_VERSION \
-  && make su-exec-static \
-  && cd /tmp \
-  && wget -q -O tini https://github.com/krallin/tini/releases/download/$TINI_VERSION/$tiniArch \
-  && chmod +x tini
-
-# Get the TLS CA certificates, they're not provided by busybox.
-RUN apt-get update && apt-get install -y ca-certificates
-
-COPY --chown=1000:users go.* $SRC_PATH/
+COPY go.* $SRC_PATH/
 WORKDIR $SRC_PATH
 RUN go mod download
 
-COPY --chown=1000:users . $SRC_PATH
+COPY . $SRC_PATH
 RUN git config --global --add safe.directory /go/src/github.com/ipfs/bifrost-gateway
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o $GOPATH/bin/bifrost-gateway
 
+RUN --mount=target=. \
+    --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o $GOPATH/bin/bifrost-gateway
 
 #------------------------------------------------------
-FROM --platform=${BUILDPLATFORM:-linux/amd64} busybox:1.34.1-glibc
-MAINTAINER IPFS Stewards <w3dt-stewards-ip@protocol.ai>
+FROM alpine:3.18
+
+# This runs bifrost-gateway
+
+# Instal binaries for $TARGETARCH
+RUN apk add --no-cache tini su-exec ca-certificates
 
 ENV GOPATH                 /go
-ENV SRC_PATH               /go/src/github.com/ipfs/bifrost-gateway
+ENV SRC_PATH               $GOPATH/src/github.com/ipfs/bifrost-gateway
 ENV BIFROST_GATEWAY_PATH   /data/bifrost-gateway
 ENV KUBO_RPC_URL           https://node0.delegate.ipfs.io,https://node1.delegate.ipfs.io,https://node2.delegate.ipfs.io,https://node3.delegate.ipfs.io
 
 COPY --from=builder $GOPATH/bin/bifrost-gateway /usr/local/bin/bifrost-gateway
 COPY --from=builder $SRC_PATH/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
-COPY --from=builder /tmp/su-exec/su-exec-static /sbin/su-exec
-COPY --from=builder /tmp/tini /sbin/tini
-COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 
 RUN mkdir -p $BIFROST_GATEWAY_PATH && \
     adduser -D -h $BIFROST_GATEWAY_PATH -u 1000 -G users ipfs && \
     chown ipfs:users $BIFROST_GATEWAY_PATH
-
 VOLUME $BIFROST_GATEWAY_PATH
+
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]
 
 CMD ["--gateway-port", "8081", "--metrics-port", "8041"]


### PR DESCRIPTION
This PR aims to remove  some overengineering around `tini`  and `su-exec` (most likely copied form ipfs-cluster/kubo) 
and use arch-specific prebuilt binaries from alpine + have static binary that is less prone to errors due to annual glibc breakfest.

I've tested this commit in `staging` and produced  `ipfs/bifrost-gateway:staging-2023-06-29-34a5f70`  runs fine on my Rpi4 (ARM64).

The size does not differ much, imo independence of glibc and ARM64 fix are worth it.

```
ipfs/bifrost-gateway:staging-latest	44.8MB (this PR)
ipfs/bifrost-gateway:main-latest	44.1MB (old setup)
```

