### PR TITLE
feat: add auth to saturn orch client

### DIFF
--- a/blockstore_caboose.go
+++ b/blockstore_caboose.go
@@ -103,5 +103,7 @@ func newCabooseBlockStore(orchestrator, loggingEndpoint string, cdns *cachedDNS)
 		DoValidation: true,
 		PoolRefresh:  caboose.DefaultPoolRefreshInterval,
 		SaturnClient: saturnRetrievalClient,
+
+		ComplianceCidPeriod: int64(100),
 	})
 }

--- a/blockstore_caboose.go
+++ b/blockstore_caboose.go
@@ -44,6 +44,7 @@ func newCabooseBlockStore(orchestrator, loggingEndpoint string, cdns *cachedDNS)
 	saturnOrchestratorClient := &http.Client{
 		Timeout: caboose.DefaultSaturnOrchestratorRequestTimeout,
 		Transport: &customTransport{
+			AuthorizationBearerToken: os.Getenv(EnvSaturnLoggerSecret),
 			RoundTripper: &http.Transport{
 				DialContext:       cdns.dialWithCachedDNS,
 				ForceAttemptHTTP2: true,

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/cskr/pubsub v1.0.2
-	github.com/filecoin-saturn/caboose v0.0.2
+	github.com/filecoin-saturn/caboose v0.0.3
 	github.com/hashicorp/golang-lru/v2 v2.0.1
 	github.com/ipfs/boxo v0.10.2-0.20230627114119-8424cf4e020a
 	github.com/ipfs/go-block-format v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/felixge/httpsnoop v1.0.0/go.mod h1:3+D9sFq0ahK/JeJPhCBUV1xlf4/eIYrUQaxulT0VzX8=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/filecoin-saturn/caboose v0.0.2 h1:xLFJ5ZF2tG+eZ29iwAUXls6TSnFQGQ5HH7GhNw4Tf3w=
-github.com/filecoin-saturn/caboose v0.0.2/go.mod h1:CSXZMijzD8z0Q/K5JQPeDZnb1o50MBK9VGZhOleqIDk=
+github.com/filecoin-saturn/caboose v0.0.3 h1:VcfNc3J6qwCAdxKIVkkCglG0ll1qL043S2qcChmUr6o=
+github.com/filecoin-saturn/caboose v0.0.3/go.mod h1:CSXZMijzD8z0Q/K5JQPeDZnb1o50MBK9VGZhOleqIDk=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=
 github.com/flynn/noise v1.0.0/go.mod h1:xbMo+0i6+IGbYdJhF31t2eR1BIU0CYc12+BNAKwUTag=


### PR DESCRIPTION
- Inject the JWT token used for logging in the orchestrator client to be used for fetching compliance cids from Saturn. 
- Update caboose to version 0.0.3
- Add a config variable to caboose that controls the compliance cid avg request frequency