### PR TITLE
feat!: IPNS routing based on IPIP-351 or IPIP-379

### DIFF
--- a/blockstore_proxy.go
+++ b/blockstore_proxy.go
@@ -24,8 +24,6 @@ import (
 
 const (
 	EnvProxyGateway = "PROXY_GATEWAY_URL"
-
-	DefaultKuboRPC = "http://127.0.0.1:5001"
 )
 
 type proxyBlockStore struct {

--- a/blockstore_proxy.go
+++ b/blockstore_proxy.go
@@ -25,8 +25,7 @@ import (
 const (
 	EnvProxyGateway = "PROXY_GATEWAY_URL"
 
-	DefaultProxyGateway = "http://127.0.0.1:8080"
-	DefaultKuboRPC      = "http://127.0.0.1:5001"
+	DefaultKuboRPC = "http://127.0.0.1:5001"
 )
 
 type proxyBlockStore struct {

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -29,9 +29,7 @@
 Default: see `DefaultKuboRPC`
 
 Single URL or a comma separated list of RPC endpoints that provide `/api/v0` from Kubo.
-
-We use this as temporary solution for IPNS Record routing until [IPIP-351](https://github.com/ipfs/specs/pull/351) ships with Kubo 0.19,
-and we also redirect some legacy `/api/v0` commands that need to be handled on `ipfs.io`.
+This is used to redirect legacy `/api/v0` commands that need to be handled on `ipfs.io`.
 
 ### `BLOCK_CACHE_SIZE`
 
@@ -59,9 +57,20 @@ in the near feature.
 
 ### `PROXY_GATEWAY_URL`
 
-Single URL or a comma separated list of Gateway endpoints that support `?format=block|car`
-responses. This is used by default with `http://127.0.0.1:8080` unless `STRN_ORCHESTRATOR_URL`
-is set.
+Single URL or a comma separated list of Gateway endpoints that support `?format=block|car|ipns-record`
+responses. Either this variable of `STRN_ORCHESTRATOR_URL` must be set.
+
+If you're gateway does not support `?format=ipns-record`, you can use `IPNS_RECORD_GATEWAY`
+to override the gateway address from which to retrieve IPNS Records from.
+
+### `IPNS_RECORD_GATEWAY`
+
+Single URL or a comma separated list of Gateway endpoints that support `?format=ipns-record`.
+This is used for IPNS Record routing. If not set, the value of `PROXY_GATEWAY_URL` will be
+used.
+
+`IPNS_RECORD_GATEWAY` also supports [Routing V1 HTTP API](https://specs.ipfs.tech/routing/http-routing-v1/)
+for IPNS Record routing. To use it, the provided URL must end with `/routing/v1`.
 
 ## Saturn Backend
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -65,11 +65,12 @@ to override the gateway address from which to retrieve IPNS Records from.
 ### `IPNS_RECORD_GATEWAY`
 
 Single URL or a comma separated list of Gateway endpoints that support requests for `application/vnd.ipfs.ipns-record`.
-This is used for IPNS Record routing. If not set, the value of `PROXY_GATEWAY_URL` will be
-used.
+This is used for IPNS Record routing.
 
 `IPNS_RECORD_GATEWAY` also supports [Routing V1 HTTP API](https://specs.ipfs.tech/routing/http-routing-v1/)
 for IPNS Record routing ([IPIP-379](https://specs.ipfs.tech/ipips/ipip-0379/)). To use it, the provided URL must end with `/routing/v1`.
+
+If not set, the IPNS records will be fetched from `KUBO_RPC_URL`.
 
 ## Saturn Backend
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -58,19 +58,19 @@ in the near feature.
 ### `PROXY_GATEWAY_URL`
 
 Single URL or a comma separated list of Gateway endpoints that support `?format=block|car|ipns-record`
-responses. Either this variable of `STRN_ORCHESTRATOR_URL` must be set.
+responses. Either this variable or `STRN_ORCHESTRATOR_URL` must be set.
 
-If you're gateway does not support `?format=ipns-record`, you can use `IPNS_RECORD_GATEWAY`
+If this gateway does not support `application/vnd.ipfs.ipns-record`, you can use `IPNS_RECORD_GATEWAY`
 to override the gateway address from which to retrieve IPNS Records from.
 
 ### `IPNS_RECORD_GATEWAY`
 
-Single URL or a comma separated list of Gateway endpoints that support `?format=ipns-record`.
+Single URL or a comma separated list of Gateway endpoints that support requests for `application/vnd.ipfs.ipns-record`.
 This is used for IPNS Record routing. If not set, the value of `PROXY_GATEWAY_URL` will be
 used.
 
 `IPNS_RECORD_GATEWAY` also supports [Routing V1 HTTP API](https://specs.ipfs.tech/routing/http-routing-v1/)
-for IPNS Record routing. To use it, the provided URL must end with `/routing/v1`.
+for IPNS Record routing ([IPIP-379](https://specs.ipfs.tech/ipips/ipip-0379/)). To use it, the provided URL must end with `/routing/v1`.
 
 ## Saturn Backend
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -59,15 +59,15 @@ in the near feature.
 Single URL or a comma separated list of Gateway endpoints that support `?format=block|car|ipns-record`
 responses. Either this variable or `STRN_ORCHESTRATOR_URL` must be set.
 
-If this gateway does not support `application/vnd.ipfs.ipns-record`, you can use `IPNS_RECORD_GATEWAY`
+If this gateway does not support `application/vnd.ipfs.ipns-record`, you can use `IPNS_RECORD_GATEWAY_URL`
 to override the gateway address from which to retrieve IPNS Records from.
 
-### `IPNS_RECORD_GATEWAY`
+### `IPNS_RECORD_GATEWAY_URL`
 
 Single URL or a comma separated list of Gateway endpoints that support requests for `application/vnd.ipfs.ipns-record`.
 This is used for IPNS Record routing.
 
-`IPNS_RECORD_GATEWAY` also supports [Routing V1 HTTP API](https://specs.ipfs.tech/routing/http-routing-v1/)
+`IPNS_RECORD_GATEWAY_URL` also supports [Routing V1 HTTP API](https://specs.ipfs.tech/routing/http-routing-v1/)
 for IPNS Record routing ([IPIP-379](https://specs.ipfs.tech/ipips/ipip-0379/)). To use it, the provided URL must end with `/routing/v1`.
 
 If not set, the IPNS records will be fetched from `KUBO_RPC_URL`.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -26,10 +26,9 @@
 
 ### `KUBO_RPC_URL`
 
-Default: see `DefaultKuboRPC`
-
 Single URL or a comma separated list of RPC endpoints that provide `/api/v0` from Kubo.
 This is used to redirect legacy `/api/v0` commands that need to be handled on `ipfs.io`.
+If this is not set, the redirects are not set up.
 
 ### `BLOCK_CACHE_SIZE`
 

--- a/handlers.go
+++ b/handlers.go
@@ -70,15 +70,15 @@ func withRequestLogger(next http.Handler) http.Handler {
 	})
 }
 
-func makeGatewayHandler(bs bstore.Blockstore, kuboRPC, gatewayURLs []string, port int, blockCacheSize int, cdns *cachedDNS, useGraphBackend bool) (*http.Server, error) {
+func makeGatewayHandler(bs bstore.Blockstore, kuboRPC, ipnsRecordGateways []string, port int, blockCacheSize int, cdns *cachedDNS, useGraphBackend bool) (*http.Server, error) {
 	// Sets up the routing system, which will proxy the IPNS routing requests to the given gateway or kubo RPC.
 	var routing routing.ValueStore
-	if len(gatewayURLs) != 0 {
-		routing = newProxyRouting(gatewayURLs, cdns)
+	if len(ipnsRecordGateways) != 0 {
+		routing = newProxyRouting(ipnsRecordGateways, cdns)
 	} else if len(kuboRPC) != 0 {
 		routing = newRPCProxyRouting(kuboRPC, cdns)
 	} else {
-		return nil, errors.New("kubo rpc or gateway urls must be provided in order to delegate routing")
+		return nil, errors.New("either KUBO_RPC_URL, IPNS_RECORD_GATEWAY_URL or PROXY_GATEWAY_URL with support for application/vnd.ipfs.ipns-record must be provided in order to delegate IPNS routing")
 	}
 
 	// Sets up a cache to store blocks in

--- a/handlers.go
+++ b/handlers.go
@@ -68,9 +68,9 @@ func withRequestLogger(next http.Handler) http.Handler {
 	})
 }
 
-func makeGatewayHandler(bs bstore.Blockstore, kuboRPC []string, port int, blockCacheSize int, cdns *cachedDNS, useGraphBackend bool) (*http.Server, error) {
+func makeGatewayHandler(bs bstore.Blockstore, kuboRPC, gatewayURLs []string, port int, blockCacheSize int, cdns *cachedDNS, useGraphBackend bool) (*http.Server, error) {
 	// Sets up the routing system, which will proxy the IPNS routing requests to the given gateway.
-	routing := newProxyRouting(kuboRPC, cdns)
+	routing := newProxyRouting(gatewayURLs, cdns)
 
 	// Sets up a cache to store blocks in
 	cacheBlockStore, err := lib.NewCacheBlockStore(blockCacheSize)

--- a/handlers.go
+++ b/handlers.go
@@ -157,10 +157,13 @@ func makeGatewayHandler(bs bstore.Blockstore, kuboRPC, gatewayURLs []string, por
 	mux := http.NewServeMux()
 	mux.Handle("/ipfs/", ipfsHandler)
 	mux.Handle("/ipns/", ipnsHandler)
-	// TODO: below is legacy which we want to remove, measuring this separately
-	// allows us to decide when is the time to do it.
-	legacyKuboRpcHandler := withHTTPMetrics(newKuboRPCHandler(kuboRPC), "legacyKuboRpc")
-	mux.Handle("/api/v0/", legacyKuboRpcHandler)
+
+	if len(kuboRPC) != 0 {
+		// TODO: below is legacy which we want to remove, measuring this separately
+		// allows us to decide when is the time to do it.
+		legacyKuboRpcHandler := withHTTPMetrics(newKuboRPCHandler(kuboRPC), "legacyKuboRpc")
+		mux.Handle("/api/v0/", legacyKuboRpcHandler)
+	}
 
 	// Construct the HTTP handler for the gateway.
 	handler := withConnect(mux)

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ See documentation at: https://github.com/ipfs/bifrost-gateway/#readme`,
 		// Get env variables.
 		saturnOrchestrator := getEnv(EnvSaturnOrchestrator, "")
 		proxyGateway := getEnvs(EnvProxyGateway, "")
-		kuboRPC := getEnvs(EnvKuboRPC, DefaultKuboRPC)
+		kuboRPC := getEnvs(EnvKuboRPC, "")
 
 		blockCacheSize, err := getEnvInt(EnvBlockCacheSize, lib.DefaultCacheBlockStoreSize)
 		if err != nil {
@@ -134,7 +134,10 @@ See documentation at: https://github.com/ipfs/bifrost-gateway/#readme`,
 			log.Printf("%s: %d", EnvBlockCacheSize, blockCacheSize)
 			log.Printf("%s: %t", EnvGraphBackend, useGraphBackend)
 
-			log.Printf("Legacy RPC at /api/v0 (%s) provided by %s", EnvKuboRPC, strings.Join(kuboRPC, " "))
+			if len(kuboRPC) != 0 {
+				log.Printf("Legacy RPC at /api/v0 (%s) provided by %s", EnvKuboRPC, strings.Join(kuboRPC, " "))
+			}
+
 			log.Printf("Path gateway listening on http://127.0.0.1:%d", gatewayPort)
 			log.Printf("  Smoke test (JPG): http://127.0.0.1:%d/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi", gatewayPort)
 			log.Printf("Subdomain gateway configured on dweb.link and http://localhost:%d", gatewayPort)

--- a/main.go
+++ b/main.go
@@ -31,10 +31,11 @@ func main() {
 }
 
 const (
-	EnvKuboRPC        = "KUBO_RPC_URL"
-	EnvBlockCacheSize = "BLOCK_CACHE_SIZE"
-	EnvGraphBackend   = "GRAPH_BACKEND"
-	RequestIDHeader   = "X-Bfid"
+	EnvKuboRPC           = "KUBO_RPC_URL"
+	EnvIPNSRecordGateway = "IPNS_RECORD_GATEWAY"
+	EnvBlockCacheSize    = "BLOCK_CACHE_SIZE"
+	EnvGraphBackend      = "GRAPH_BACKEND"
+	RequestIDHeader      = "X-Bfid"
 )
 
 func init() {
@@ -107,7 +108,12 @@ See documentation at: https://github.com/ipfs/bifrost-gateway/#readme`,
 			log.Fatalf("Unable to start. bifrost-gateway requires either PROXY_GATEWAY_URL or STRN_ORCHESTRATOR_URL to be set.\n\nRead docs at https://github.com/ipfs/bifrost-gateway/blob/main/docs/environment-variables.md\n\n")
 		}
 
-		gatewaySrv, err := makeGatewayHandler(bs, kuboRPC, gatewayPort, blockCacheSize, cdns, useGraphBackend)
+		ipnsProxyGateway := getEnvs(EnvIPNSRecordGateway, "")
+		if len(ipnsProxyGateway) == 0 {
+			ipnsProxyGateway = proxyGateway
+		}
+
+		gatewaySrv, err := makeGatewayHandler(bs, kuboRPC, ipnsProxyGateway, gatewayPort, blockCacheSize, cdns, useGraphBackend)
 		if err != nil {
 			return err
 		}

--- a/main.go
+++ b/main.go
@@ -109,10 +109,6 @@ See documentation at: https://github.com/ipfs/bifrost-gateway/#readme`,
 		}
 
 		ipnsProxyGateway := getEnvs(EnvIPNSRecordGateway, "")
-		if len(ipnsProxyGateway) == 0 {
-			ipnsProxyGateway = proxyGateway
-		}
-
 		gatewaySrv, err := makeGatewayHandler(bs, kuboRPC, ipnsProxyGateway, gatewayPort, blockCacheSize, cdns, useGraphBackend)
 		if err != nil {
 			return err

--- a/routing.go
+++ b/routing.go
@@ -135,5 +135,5 @@ func (ps *proxyRouting) fetch(ctx context.Context, name ipns.Name) ([]byte, erro
 }
 
 func (ps *proxyRouting) getRandomGatewayURL() string {
-	return ps.gatewayURLs[ps.rand.Intn(len(ps.gatewayURLs))]
+	return strings.TrimSuffix(ps.gatewayURLs[ps.rand.Intn(len(ps.gatewayURLs))], "/")
 }

--- a/routing.go
+++ b/routing.go
@@ -156,17 +156,17 @@ func (ps *rpcProxyRouting) getRandomKuboURL() string {
 }
 
 type proxyRouting struct {
-	gatewayURLs []string
-	httpClient  *http.Client
-	rand        *rand.Rand
+	ipnsRecordGateways []string
+	httpClient         *http.Client
+	rand               *rand.Rand
 }
 
-func newProxyRouting(gatewayURLs []string, cdns *cachedDNS) routing.ValueStore {
+func newProxyRouting(ipnsRecordGateways []string, cdns *cachedDNS) routing.ValueStore {
 	s := rand.NewSource(time.Now().Unix())
 	rand := rand.New(s)
 
 	return &proxyRouting{
-		gatewayURLs: gatewayURLs,
+		ipnsRecordGateways: ipnsRecordGateways,
 		httpClient: &http.Client{
 			Transport: otelhttp.NewTransport(&customTransport{
 				// RoundTripper with increased defaults than http.Transport such that retrieving
@@ -276,5 +276,5 @@ func (ps *proxyRouting) fetch(ctx context.Context, name ipns.Name) ([]byte, erro
 }
 
 func (ps *proxyRouting) getRandomGatewayURL() string {
-	return strings.TrimSuffix(ps.gatewayURLs[ps.rand.Intn(len(ps.gatewayURLs))], "/")
+	return strings.TrimSuffix(ps.ipnsRecordGateways[ps.rand.Intn(len(ps.ipnsRecordGateways))], "/")
 }

--- a/routing.go
+++ b/routing.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -13,6 +17,143 @@ import (
 	"github.com/libp2p/go-libp2p/core/routing"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
+
+type rpcProxyRouting struct {
+	kuboRPC    []string
+	httpClient *http.Client
+	rand       *rand.Rand
+}
+
+func newRPCProxyRouting(kuboRPC []string, cdns *cachedDNS) routing.ValueStore {
+	s := rand.NewSource(time.Now().Unix())
+	rand := rand.New(s)
+
+	return &rpcProxyRouting{
+		kuboRPC: kuboRPC,
+		httpClient: &http.Client{
+			Transport: otelhttp.NewTransport(&customTransport{
+				// Roundtripper with increased defaults than http.Transport such that retrieving
+				// multiple lookups concurrently is fast.
+				RoundTripper: &http.Transport{
+					MaxIdleConns:        1000,
+					MaxConnsPerHost:     100,
+					MaxIdleConnsPerHost: 100,
+					IdleConnTimeout:     90 * time.Second,
+					DialContext:         cdns.dialWithCachedDNS,
+					ForceAttemptHTTP2:   true,
+				},
+			}),
+		},
+		rand: rand,
+	}
+}
+
+func (ps *rpcProxyRouting) PutValue(context.Context, string, []byte, ...routing.Option) error {
+	return routing.ErrNotSupported
+}
+
+func (ps *rpcProxyRouting) GetValue(ctx context.Context, k string, opts ...routing.Option) ([]byte, error) {
+	return ps.fetch(ctx, k)
+}
+
+func (ps *rpcProxyRouting) SearchValue(ctx context.Context, k string, opts ...routing.Option) (<-chan []byte, error) {
+	if !strings.HasPrefix(k, "/ipns/") {
+		return nil, routing.ErrNotSupported
+	}
+
+	ch := make(chan []byte)
+
+	go func() {
+		v, err := ps.fetch(ctx, k)
+		if err != nil {
+			close(ch)
+		} else {
+			ch <- v
+			close(ch)
+		}
+	}()
+
+	return ch, nil
+}
+
+func (ps *rpcProxyRouting) fetch(ctx context.Context, key string) (rb []byte, err error) {
+	name, err := ipns.NameFromRoutingKey([]byte(key))
+	if err != nil {
+		return nil, err
+	}
+
+	key = "/ipns/" + name.String()
+
+	urlStr := fmt.Sprintf("%s/api/v0/dht/get?arg=%s", ps.getRandomKuboURL(), key)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, urlStr, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	goLog.Debugw("routing proxy fetch", "key", key, "from", req.URL.String())
+	defer func() {
+		if err != nil {
+			goLog.Debugw("routing proxy fetch error", "key", key, "from", req.URL.String(), "error", err.Error())
+		}
+	}()
+
+	resp, err := ps.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	// Read at most 10 KiB (max size of IPNS record).
+	rb, err = io.ReadAll(io.LimitReader(resp.Body, 10240))
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("routing/get RPC returned unexpected status: %s, body: %q", resp.Status, string(rb))
+	}
+
+	parts := bytes.Split(bytes.TrimSpace(rb), []byte("\n"))
+	var b64 string
+
+	for _, part := range parts {
+		var evt routing.QueryEvent
+		err = json.Unmarshal(part, &evt)
+		if err != nil {
+			return nil, fmt.Errorf("routing/get RPC response cannot be parsed: %w", err)
+		}
+
+		if evt.Type == routing.Value {
+			b64 = evt.Extra
+			break
+		}
+	}
+
+	if b64 == "" {
+		return nil, errors.New("routing/get RPC returned no value")
+	}
+
+	rb, err = base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return nil, err
+	}
+
+	entry, err := ipns.UnmarshalRecord(rb)
+	if err != nil {
+		return nil, err
+	}
+
+	err = ipns.ValidateWithName(entry, name)
+	if err != nil {
+		return nil, err
+	}
+
+	return rb, nil
+}
+
+func (ps *rpcProxyRouting) getRandomKuboURL() string {
+	return ps.kuboRPC[ps.rand.Intn(len(ps.kuboRPC))]
+}
 
 type proxyRouting struct {
 	gatewayURLs []string


### PR DESCRIPTION
Towards  #151, allows resolving IPNS without `KUBO_RPC_URL` being set
-  adds `IPNS_RECORD_GATEWAY_URL`
- uses either legacy  `KUBO_RPC_URL` or modern `IPNS_RECORD_GATEWAY_URL` or `PROXY_GATEWAY_URL` with support for `application/vnd.ipfs.ipns-record`  responses


Not sure what to do regarding testing here. We haven't had testing before and it seems a bit complicated to automate. I tried locally with both Kubo gateway and Routing V1 and it worked 🥳 